### PR TITLE
Read the size from a different variable

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -150,7 +150,7 @@ func (w *Writer) Close() error {
 	}
 
 	// write chunk size
-	err = binary.Write(w, binary.LittleEndian, w.bytesWritten)
+	err = binary.Write(w, binary.LittleEndian, int32(w.bytesWritten))
 	if err != nil {
 		return err
 	}

--- a/writer.go
+++ b/writer.go
@@ -150,9 +150,7 @@ func (w *Writer) Close() error {
 	}
 
 	// write chunk size
-	var dataSize int32
-	dataSize = w.samplesWritten * 4
-	err = binary.Write(w, binary.LittleEndian, dataSize)
+	err = binary.Write(w, binary.LittleEndian, w.bytesWritten)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Corrects issue when using WriteSample, bytesWritten != samplesWritten * 4

I ran into this when writing a bunch of 16-bit samples - players would think the .wav went twice as long as it actually did, as the size assumes 32-bit samples. W already has bytesWritten which tracks this correctly, I think?