### PR TITLE
Updated Codebase. Added wav.Reader.Reset() and wav.Reader.ReadSampleEvery()

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,16 +6,21 @@ import (
 )
 
 var (
+	// ErrInputToLarge error
 	ErrInputToLarge = errors.New("Input too large")
-	ErrNotRiff      = errors.New("Not a RIFF file")
-	ErrNotWave      = errors.New("Not a WAVE file")
-
-	ErrBrokenChunkFmt  = errors.New("could not decode chunkFmt")
+	// ErrNotRiff error
+	ErrNotRiff = errors.New("Not a RIFF file")
+	// ErrNotWave error
+	ErrNotWave = errors.New("Not a WAVE file")
+	// ErrBrokenChunkFmt error
+	ErrBrokenChunkFmt = errors.New("could not decode chunkFmt")
+	// ErrNoBitsPerSample error
 	ErrNoBitsPerSample = errors.New("could not decode chunkFmt")
-
+	// ErrFormatNotSupported error
 	ErrFormatNotSupported = errors.New("Format not supported - Only uncompressed PCM currently")
 )
 
+// ErrIncorrectChunkSize struct
 type ErrIncorrectChunkSize struct {
 	Got, Wanted uint32
 }

--- a/examples/simpleReadEvery/main.go
+++ b/examples/simpleReadEvery/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/xeoncross/wav"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: simpleReadEvery <file.wav>\n")
+		os.Exit(1)
+	}
+	testInfo, err := os.Stat(os.Args[1])
+	checkErr(err)
+
+	testWav, err := os.Open(os.Args[1])
+	checkErr(err)
+
+	wavReader, err := wav.NewReader(testWav, testInfo.Size())
+	checkErr(err)
+
+	fmt.Println("Hello, wav")
+	fmt.Println(wavReader)
+
+	// Load file meta
+	var meta wav.File
+	meta = wavReader.GetFile()
+
+	// Every half a second read a sample
+	readSampleRate := meta.SampleRate / uint32(2)
+	fmt.Println("Read a sample every", readSampleRate)
+
+	samples, err := wavReader.ReadSampleEvery(readSampleRate)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Samples found %d, Estimated: %d\n", len(samples), meta.NumberOfSamples/readSampleRate+1)
+
+	var second uint32
+	for i, sample := range samples {
+
+		pos := uint32(i)
+
+		// What second of audio are we on?
+		second = readSampleRate * pos / meta.SampleRate
+
+		fmt.Printf("Second %d\tSample: %d\tAmplitude: %d\n", second, pos*readSampleRate, sample)
+	}
+
+}
+
+func checkErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/examples/simpleReadEvery/main.go
+++ b/examples/simpleReadEvery/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/xeoncross/wav"
+	"github.com/cryptix/wav"
 )
 
 func main() {

--- a/examples/simpleReadEvery/main.go
+++ b/examples/simpleReadEvery/main.go
@@ -30,10 +30,14 @@ func main() {
 	meta = wavReader.GetFile()
 
 	// Every half a second read a sample
-	readSampleRate := meta.SampleRate / uint32(2)
+	readSampleRate := meta.SampleRate / uint32(4)
 	fmt.Println("Read a sample every", readSampleRate)
 
-	samples, err := wavReader.ReadSampleEvery(readSampleRate)
+	// Number of samples to average together (if any)
+	var averageBy int
+	averageBy = 20 // 10, 40, 345, 1000, etc...
+
+	samples, err := wavReader.ReadSampleEvery(readSampleRate, averageBy)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/headers.go
+++ b/headers.go
@@ -1,5 +1,7 @@
 package wav
 
+import "time"
+
 const (
 	maxSize = 2 << 31
 )
@@ -11,10 +13,17 @@ var (
 	tokenData       = [4]byte{'d', 'a', 't', 'a'}
 )
 
+// File describes the WAV file
 type File struct {
 	SampleRate      uint32
 	SignificantBits uint16
 	Channels        uint16
+	NumberOfSamples uint32
+	Duration        time.Duration
+	AudioFormat     uint16
+	SoundSize       uint32
+	Canonical       bool
+	BytesPerSecond  uint32
 }
 
 // 12 byte header

--- a/reader.go
+++ b/reader.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+// Reader wraps WAV stream
 type Reader struct {
 	input io.ReadSeeker
 	size  int64
@@ -44,6 +45,7 @@ func (wav Reader) String() string {
 	return msg
 }
 
+// NewReader returns a new WAV reader wrapper
 func NewReader(rd io.ReadSeeker, size int64) (wav *Reader, err error) {
 	if size > maxSize {
 		return nil, ErrInputToLarge
@@ -174,20 +176,39 @@ func (wav *Reader) parseChunkFmt() (err error) {
 	return nil
 }
 
+// GetSampleCount returns the number of samples
 func (wav *Reader) GetSampleCount() uint32 {
 	return wav.numSamples
 }
 
-func (w Reader) GetFile() File {
+// GetFile returns File
+func (wav Reader) GetFile() File {
 	return File{
-		SampleRate:      w.chunkFmt.SampleRate,
-		Channels:        w.chunkFmt.NumChannels,
-		SignificantBits: w.chunkFmt.BitsPerSample,
+		SampleRate:      wav.chunkFmt.SampleRate,
+		Channels:        wav.chunkFmt.NumChannels,
+		SignificantBits: wav.chunkFmt.BitsPerSample,
+		BytesPerSecond:  wav.chunkFmt.BytesPerSec,
+		AudioFormat:     wav.chunkFmt.AudioFormat,
+		NumberOfSamples: wav.numSamples,
+		SoundSize:       wav.dataBlocSize,
+		Duration:        wav.duration,
+		Canonical:       wav.canonical && !wav.extraChunk,
 	}
 }
 
+// FirstSampleOffset in the WAV stream
 func (wav Reader) FirstSampleOffset() uint32 {
 	return wav.firstSamplePos
+}
+
+// Reset the wavReader
+func (wav Reader) Reset() (err error) {
+	_, err = wav.input.Seek(int64(wav.firstSamplePos), os.SEEK_SET)
+	if err == nil {
+		wav.samplesRead = 0
+	}
+
+	return
 }
 
 // GetDumbReader gives you a std io.Reader, starting from the first sample. usefull for piping data.
@@ -201,6 +222,7 @@ func (wav Reader) GetDumbReader() (r io.Reader, err error) {
 	return wav.input, nil
 }
 
+// ReadRawSample returns the raw []byte slice
 func (wav *Reader) ReadRawSample() ([]byte, error) {
 	if wav.samplesRead > wav.numSamples {
 		return nil, io.EOF
@@ -216,11 +238,12 @@ func (wav *Reader) ReadRawSample() ([]byte, error) {
 		return nil, fmt.Errorf("Read %d bytes, should have read %d", n, wav.bytesPerSample)
 	}
 
-	wav.samplesRead += 1
+	wav.samplesRead++
 
 	return buf, nil
 }
 
+// ReadSample returns the parsed sample bytes as integers
 func (wav *Reader) ReadSample() (n int32, err error) {
 	s, err := wav.ReadRawSample()
 	if err != nil {
@@ -243,3 +266,102 @@ func (wav *Reader) ReadSample() (n int32, err error) {
 
 	return
 }
+
+// ReadSampleEvery returns the parsed sample bytes as integers every X samples
+func (wav *Reader) ReadSampleEvery(every uint32) (samples []int32, err error) {
+
+	// Reset any other readers
+	err = wav.Reset()
+	if err != nil {
+		return
+	}
+
+	var n int32
+	var total int
+	total = int(wav.numSamples / every)
+	for total >= 0 {
+		total = total - 1
+
+		n, err = wav.ReadSample()
+		if err != nil {
+			return
+		}
+
+		samples = append(samples, n)
+
+		_, err = wav.input.Seek(int64(every), os.SEEK_CUR)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+/*
+// Sample of WAV
+type Sample struct {
+	Offset uint32
+	Value  int32
+	Second uint32
+}
+
+// ReadSampleChannelEvery X samples delivered over a channel
+func (wav *Reader) ReadSampleChannelEvery(every uint32) (c chan *Sample, e chan error) {
+
+	// Save resources by making a channel to range over
+	c = make(chan *Sample, 100)
+	e = make(chan error)
+
+	go func() {
+
+		var err error
+
+		// Reset any other readers
+		wav.samplesRead = 0
+
+		// Start from the begining
+		_, err = wav.input.Seek(int64(wav.firstSamplePos), os.SEEK_SET)
+		if err != nil {
+			close(c)
+			e <- err
+			return
+		}
+
+		var n int32
+		var total int
+		var pos uint32
+		total = int(wav.numSamples / every)
+		for total >= 0 {
+			total = total - 1
+			pos += every
+
+			// Read a sample
+			n, err = wav.ReadSample()
+			if err != nil {
+				close(c)
+				e <- err
+				return
+			}
+
+			c <- &Sample{
+				Offset: pos,
+				Second: pos / wav.chunkFmt.SampleRate,
+				Value:  n,
+			}
+
+			_, err = wav.input.Seek(int64(every), os.SEEK_CUR)
+			if err != nil {
+				close(c)
+				e <- err
+				return
+			}
+		}
+
+		// Reset any other readers
+		wav.samplesRead = 0
+	}()
+
+	return
+}
+*/

--- a/reader_test.go
+++ b/reader_test.go
@@ -68,6 +68,9 @@ func TestParseHeaders_complete(t *testing.T) {
 		SampleRate:      44100,
 		Channels:        1,
 		SignificantBits: 16,
+		AudioFormat:     1,
+		Canonical:       true,
+		BytesPerSecond:  88200,
 	}, wavReader.GetFile())
 }
 

--- a/rw_test.go
+++ b/rw_test.go
@@ -35,7 +35,7 @@ func TestWriteRead_Int32(t *testing.T) {
 	freq = 0.0001
 
 	// one second
-	for n := 0; n < rate; n += 1 {
+	for n := 0; n < rate; n++ {
 		y := int32(0.8 * math.Pow(2, bits-1) * math.Sin(freq*float64(n)))
 		freq += 0.000002
 
@@ -86,7 +86,7 @@ func TestWriteRead_Sample(t *testing.T) {
 
 	var s = make([]byte, 2)
 	// one second
-	for n := 0; n < rate; n += 1 {
+	for n := 0; n < rate; n++ {
 		y := int32(0.8 * math.Pow(2, bits-1) * math.Sin(freq*float64(n)))
 		freq += 0.000002
 

--- a/writer.go
+++ b/writer.go
@@ -112,7 +112,7 @@ func (w *Writer) WriteSample(sample []byte) error {
 }
 
 // GetDumbWriter gives you a std io.Writer, starting from the first sample. usefull for piping data.
-func (w *Writer) GetDumbWriter() (wr output, countPtr *int32, err error) {
+func (w *Writer) GetDumbWriter() (io.Writer, *int32, error) {
 	if w.samplesWritten != 0 {
 		return nil, nil, fmt.Errorf("Please only use this on its own")
 	}


### PR DESCRIPTION
- updated the codebase to fix `gofmt` warnings.
- Added `wav.Reader.Reset()` so the same reader can be reused
- Added more meta data to the `wav.File` struct so it would be more useful
- Added `wav.Reader.ReadSampleEvery()` method to make it easy to skip through files sampling amplitude
- Added `example/` for `wav.Reader.ReadSampleEvery()`