### PR TITLE
Fix writer, byteswritten

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -20,8 +20,7 @@ type Writer struct {
 	options   File
 	sampleBuf *bufio.Writer
 
-	samplesWritten int32
-	bytesWritten   int
+	bytesWritten int
 }
 
 // NewWriter creates a new WaveWriter and writes the header to it
@@ -37,14 +36,13 @@ func (file File) NewWriter(out output) (wr *Writer, err error) {
 	wr.options = file
 
 	// write header when close to get correct number of samples
-	wr.samplesWritten = 0
 	_, err = wr.Seek(12, os.SEEK_SET)
 	if err != nil {
 		return
 	}
 
 	// fmt.Fprintf(wr, "%s", tokenChunkFmt)
-	n, err := wr.Write(tokenChunkFmt[:])
+	n, err := wr.output.Write(tokenChunkFmt[:])
 	if err != nil {
 		return
 	}
@@ -60,13 +58,13 @@ func (file File) NewWriter(out output) (wr *Writer, err error) {
 		BitsPerSample:  file.SignificantBits,
 	}
 
-	err = binary.Write(wr, binary.LittleEndian, chunkFmt)
+	err = binary.Write(wr.output, binary.LittleEndian, chunkFmt)
 	if err != nil {
 		return
 	}
 	wr.bytesWritten += 20 //sizeof riffChunkFmt
 
-	n, err = wr.Write(tokenData[:])
+	n, err = wr.output.Write(tokenData[:])
 	if err != nil {
 		return
 	}
@@ -88,7 +86,6 @@ func (w *Writer) WriteInt32(sample int32) error {
 		return err
 	}
 
-	w.samplesWritten++
 	w.bytesWritten += 4
 
 	return err
@@ -105,24 +102,19 @@ func (w *Writer) WriteSample(sample []byte) error {
 		return err
 	}
 
-	w.samplesWritten++
 	w.bytesWritten += n
 
 	return nil
 }
 
-// GetDumbWriter gives you a std io.Writer, starting from the first sample. usefull for piping data.
-func (w *Writer) GetDumbWriter() (io.Writer, *int32, error) {
-	if w.samplesWritten != 0 {
-		return nil, nil, fmt.Errorf("Please only use this on its own")
-	}
-
-	return w, &w.samplesWritten, nil
+func (w *Writer) Write(data []byte) (int, error) {
+	n, err := w.output.Write(data)
+	w.bytesWritten += n
+	return n, err
 }
 
 // Close corrects the filesize information in the header
 func (w *Writer) Close() error {
-
 	if err := w.sampleBuf.Flush(); err != nil {
 		return err
 	}
@@ -138,7 +130,7 @@ func (w *Writer) Close() error {
 	copy(header.Ftype[:], tokenRiff[:])
 	copy(header.ChunkFormat[:], tokenWaveFormat[:])
 
-	err = binary.Write(w, binary.LittleEndian, header)
+	err = binary.Write(w.output, binary.LittleEndian, header)
 	if err != nil {
 		return err
 	}
@@ -150,7 +142,7 @@ func (w *Writer) Close() error {
 	}
 
 	// write chunk size
-	err = binary.Write(w, binary.LittleEndian, int32(w.bytesWritten))
+	err = binary.Write(w.output, binary.LittleEndian, int32(w.bytesWritten))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This makes the `*wav.Writer` be an `io.Writer` directly, instead of requiring the `GetDumbWriter` method. Also fixes the apparent confusion between bytes written and samples written, where it would track `samplesWritten` but not actually do anything with it, while writing a zero `bytesWritten` at the end.