### PR TITLE
Pass by reference on reader Reset

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -203,7 +203,7 @@ func (wav Reader) FirstSampleOffset() uint32 {
 }
 
 // Reset the wavReader
-func (wav Reader) Reset() (err error) {
+func (wav *Reader) Reset() (err error) {
 	_, err = wav.input.Seek(int64(wav.firstSamplePos), os.SEEK_SET)
 	if err == nil {
 		wav.samplesRead = 0


### PR DESCRIPTION
It looks like the current implementation won't reset the Reader's position since the reader is passed by value. This PR changes that to a pass by reference so that calling `Reset()` on a reader should reset the reader itself's position.